### PR TITLE
Typo in halo.py

### DIFF
--- a/app/donlib/halo.py
+++ b/app/donlib/halo.py
@@ -147,7 +147,7 @@ class Halo(object):
                "\"tell me about group `(group_id|group_name)`\"\n" +
                "\"list all servers\"\n" +
                "\"list server groups\"\n" +
-               "\"severs with CVE `cve_id`\"\n" +
+               "\"servers with CVE `cve_id`\"\n" +
                "\"servers in group `(group_id|group_name)`\"\n" +
                "\"group firewall `(group_id|group_name)`\"\n" +
                "\"ec2 halo footprint csv\"\n" +


### PR DESCRIPTION
Specifically under help_text